### PR TITLE
feat: integrate docker sdk and add /docker-status endpoint (#2)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,3 +28,22 @@ docker run --env-file .env -p 8000:8000 launchpad-backend
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | /health | None | Service health check |
+| GET | /docker-status | None* | List all running containers |
+
+\* Auth not yet implemented — will require bearer token in a future ticket.
+
+## Docker socket access
+
+`/docker-status` talks to the Docker daemon via the Docker SDK. When running
+locally the SDK connects through `/var/run/docker.sock` automatically.
+
+When running inside Docker you must bind-mount the socket:
+
+```bash
+docker run --env-file .env -p 8000:8000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  launchpad-backend
+```
+
+The socket is never exposed publicly — only the backend process has access to it,
+per the security architecture in `docs/decisions/002-security-architecture.md`.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.12
 uvicorn[standard]==0.34.2
 python-dotenv==1.1.0
+docker==7.1.0

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,6 +1,9 @@
 """Entry point for the Launchpad FastAPI backend."""
 
+import docker
+import docker.errors
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 app = FastAPI(title="Launchpad", version="0.1.0")
 
@@ -9,3 +12,47 @@ app = FastAPI(title="Launchpad", version="0.1.0")
 async def health() -> dict:
     """Return service health status. No authentication required."""
     return {"status": "ok", "version": "0.1.0"}
+
+
+@app.get("/docker-status", tags=["docker"])
+async def docker_status() -> JSONResponse:
+    """List and inspect all running containers via the Docker SDK.
+
+    Returns a list of running containers, each with their id, status,
+    image name, and port mappings. Returns 503 if Docker is unreachable
+    and an empty list if Docker is running but no containers are active.
+    """
+    try:
+        client = docker.from_env()
+        containers = client.containers.list()
+    except docker.errors.DockerException:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Docker daemon is not reachable"},
+        )
+
+    if not containers:
+        return JSONResponse(content={"containers": []})
+
+    result = []
+    for container in containers:
+        result.append({
+            "container_id": container.short_id,
+            "status": container.status,
+            "image": container.image.tags[0] if container.image.tags else container.image.short_id,
+            "ports": _format_ports(container.ports),
+        })
+
+    return JSONResponse(content={"containers": result})
+
+
+def _format_ports(ports: dict) -> list[str]:
+    """Convert Docker SDK port dict into readable 'host:container/proto' strings."""
+    formatted = []
+    for container_port, host_bindings in ports.items():
+        if host_bindings:
+            for binding in host_bindings:
+                formatted.append(f"{binding['HostPort']}:{container_port}")
+        else:
+            formatted.append(container_port)
+    return formatted


### PR DESCRIPTION
## What this PR does

created a new endpoint /docker-status
added new dependencies
updated the backend README.md
added a docker.sock in order for the FastAPI to be able to communicate with docker from inside the container

## Related ticket

Closes #2 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

boot up the server through port 8000
curl to get the /health endpoint first 
curl to get the /docker-status info, no container is running so the return was empty 

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
