### PR TITLE
feat: build service for dockedr files from given GitHub repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv/
 __pycache__/
 *.pyc
+tmp/

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,8 +29,27 @@ docker run --env-file .env -p 8000:8000 launchpad-backend
 |--------|------|------|-------------|
 | GET | /health | None | Service health check |
 | GET | /docker-status | None* | List all running containers |
+| POST | /build-service | None* | Clone a GitHub repo and build a Docker image |
 
 \* Auth not yet implemented — will require bearer token in a future ticket.
+
+## Build service
+
+`POST /build-service` accepts a JSON body:
+
+```json
+{ "repo_url": "https://github.com/owner/repo" }
+```
+
+The endpoint:
+1. Validates the URL is a GitHub URL
+2. Checks the repository exists via the GitHub API
+3. Clones the repo into `backend/tmp/<owner>-<repo>/`
+4. Verifies a `Dockerfile` exists at the repo root
+5. Builds and tags the image as `launchpad/<owner>-<repo>:latest`
+6. Deletes the temporary clone regardless of build outcome
+
+The `tmp/` directory is git-ignored and never committed.
 
 ## Docker socket access
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi==0.115.12
 uvicorn[standard]==0.34.2
 python-dotenv==1.1.0
 docker==7.1.0
+gitpython==3.1.44
+httpx==0.28.1

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,12 +1,36 @@
 """Entry point for the Launchpad FastAPI backend."""
 
+import shutil
+from pathlib import Path
+from urllib.parse import urlparse
+
 import docker
 import docker.errors
+import git
+import git.exc
+import httpx
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 app = FastAPI(title="Launchpad", version="0.1.0")
 
+TMP_DIR = Path(__file__).parent.parent / "tmp"
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+class BuildRequest(BaseModel):
+    """Payload for the /build-service endpoint."""
+
+    repo_url: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
 
 @app.get("/health", tags=["meta"])
 async def health() -> dict:
@@ -46,6 +70,120 @@ async def docker_status() -> JSONResponse:
     return JSONResponse(content={"containers": result})
 
 
+@app.post("/build-service", tags=["build"])
+async def build_service(request: BuildRequest) -> JSONResponse:
+    """Clone a public GitHub repository and build a Docker image from its Dockerfile.
+
+    Validates the URL is a GitHub repo, checks the repo exists, clones it into
+    a temporary directory, verifies a Dockerfile is present, then builds and tags
+    the image. The temporary clone is always removed after the build attempt.
+    """
+    if not _is_github_url(request.repo_url):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "URL must point to a GitHub repository (https://github.com/owner/repo)"},
+        )
+
+    owner, repo_name = _extract_repo_info(request.repo_url)
+    if not owner or not repo_name:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Could not parse owner and repository name from URL"},
+        )
+
+    # Verify repo exists on GitHub before attempting a clone
+    async with httpx.AsyncClient() as http:
+        try:
+            gh_response = await http.get(
+                f"https://api.github.com/repos/{owner}/{repo_name}",
+                headers={"Accept": "application/vnd.github+json"},
+                timeout=10,
+            )
+        except httpx.RequestError:
+            return JSONResponse(
+                status_code=502,
+                content={"error": "Could not reach GitHub API to verify repository"},
+            )
+
+    if gh_response.status_code == 404:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"Repository '{owner}/{repo_name}' not found on GitHub"},
+        )
+    if gh_response.status_code != 200:
+        return JSONResponse(
+            status_code=502,
+            content={"error": "GitHub API returned an unexpected response"},
+        )
+
+    # Clone into tmp/<owner>-<repo_name>; always clean up afterwards
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    clone_path = TMP_DIR / f"{owner}-{repo_name}"
+
+    if clone_path.exists():
+        shutil.rmtree(clone_path)
+
+    try:
+        git.Repo.clone_from(request.repo_url, str(clone_path))
+    except git.exc.GitCommandNotFound:
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Git is not installed on this server"},
+        )
+    except git.exc.GitCommandError as e:
+        return JSONResponse(
+            status_code=500,
+            content={"error": f"Failed to clone repository: {str(e).strip()}"},
+        )
+
+    try:
+        if not (clone_path / "Dockerfile").exists():
+            return JSONResponse(
+                status_code=422,
+                content={"error": f"No Dockerfile found in '{owner}/{repo_name}'"},
+            )
+
+        image_tag = f"launchpad/{owner}-{repo_name.lower()}:latest"
+
+        try:
+            docker_client = docker.from_env()
+            image, _ = docker_client.images.build(
+                path=str(clone_path),
+                tag=image_tag,
+                rm=True,
+            )
+        except docker.errors.BuildError as e:
+            build_log = "\n".join(
+                line.get("stream", "").strip()
+                for line in e.build_log
+                if line.get("stream", "").strip()
+            )
+            return JSONResponse(
+                status_code=500,
+                content={"error": "Docker build failed", "details": build_log},
+            )
+        except docker.errors.DockerException:
+            return JSONResponse(
+                status_code=503,
+                content={"error": "Docker daemon is not reachable"},
+            )
+    finally:
+        shutil.rmtree(clone_path, ignore_errors=True)
+
+    return JSONResponse(
+        status_code=201,
+        content={
+            "message": "Image built successfully",
+            "image": image_tag,
+            "repo": f"{owner}/{repo_name}",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 def _format_ports(ports: dict) -> list[str]:
     """Convert Docker SDK port dict into readable 'host:container/proto' strings."""
     formatted = []
@@ -56,3 +194,27 @@ def _format_ports(ports: dict) -> list[str]:
         else:
             formatted.append(container_port)
     return formatted
+
+
+def _is_github_url(url: str) -> bool:
+    """Return True if the URL points to github.com over http/https."""
+    try:
+        parsed = urlparse(url)
+        return parsed.scheme in ("https", "http") and parsed.netloc in ("github.com", "www.github.com")
+    except Exception:
+        return False
+
+
+def _extract_repo_info(url: str) -> tuple[str, str] | tuple[None, None]:
+    """Parse owner and repo name from a GitHub URL.
+
+    Handles both https://github.com/owner/repo and .git suffixed variants.
+    """
+    try:
+        path = urlparse(url).path.strip("/").removesuffix(".git")
+        parts = path.split("/")
+        if len(parts) >= 2 and parts[0] and parts[1]:
+            return parts[0], parts[1]
+    except Exception:
+        pass
+    return None, None


### PR DESCRIPTION
## What this PR does

clones a repo from a given GitHub URL into a tmp/ folder
makes sure that the url is for a GitHub repo, the repo exists, a Dockerfile exists inside
builds the images and tags it using the owner and repo names
return relevant error requests for each failure  mode

## Related ticket

Closes #3 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

tested on 3 different URL and passed all the tests
repo without a docker file in root dir
repo with a docker file in root dir
non GitHub URL 

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
