### PR TITLE
fix: catch APIError seperately and lowercase image tags (#3)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -143,7 +143,7 @@ async def build_service(request: BuildRequest) -> JSONResponse:
                 content={"error": f"No Dockerfile found in '{owner}/{repo_name}'"},
             )
 
-        image_tag = f"launchpad/{owner}-{repo_name.lower()}:latest"
+        image_tag = f"launchpad/{owner.lower()}-{repo_name.lower()}:latest"
 
         try:
             docker_client = docker.from_env()
@@ -162,10 +162,15 @@ async def build_service(request: BuildRequest) -> JSONResponse:
                 status_code=500,
                 content={"error": "Docker build failed", "details": build_log},
             )
-        except docker.errors.DockerException:
+        except docker.errors.APIError as e:
+            return JSONResponse(
+                status_code=500,
+                content={"error": f"Docker API error: {e.explanation}"},
+            )
+        except docker.errors.DockerException as e:
             return JSONResponse(
                 status_code=503,
-                content={"error": "Docker daemon is not reachable"},
+                content={"error": f"Docker daemon is not reachable: {str(e)}"},
             )
     finally:
         shutil.rmtree(clone_path, ignore_errors=True)


### PR DESCRIPTION
## What this PR does

2 bugs found during testing:
  1. APIError not caught separately — it was being swallowed by the broad DockerException handler, hiding the real error message. 
  2. Uppercase owner in image tag — Docker requires all-lowercase image names; Anyth3nG → anyth3ng  

## Related ticket

Closes #3 

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure

## Testing done

● Posted a POST /build-service request with https://github.com/Anyth3nG/test-repo and got back a 201 with "image":                           
  "launchpad/anyth3ng-test-repo:latest", confirming the full clone → Dockerfile check → Docker build → cleanup flow ran successfully.  

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [ ] Documentation updated if needed
