### PR TITLE
feat: image deployment + relevant documenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ like Railway and Render work under the hood.
 
 ## What it does
 
-- Accepts a GitHub repository URL and builds it as a Docker container
-- Deploys the container and assigns it a local URL via reverse proxy
-- Monitors running services with health checks and restart policies
+- Accepts a GitHub repository URL and builds it as a Docker image
+- Deploys built images as containers with enforced CPU and memory resource limits
+- Auto-assigns host ports so deployed services are immediately reachable
+- Monitors running containers and surfaces status via a REST API
 - Provides a React dashboard for managing deployments and viewing logs
 - Supports GitHub webhook integration for automatic deploys on push
 - Includes a CLI tool for terminal-based deployments

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,6 +30,7 @@ docker run --env-file .env -p 8000:8000 launchpad-backend
 | GET | /health | None | Service health check |
 | GET | /docker-status | None* | List all running containers |
 | POST | /build-service | None* | Clone a GitHub repo and build a Docker image |
+| POST | /container-deployment | None* | Deploy a built image as a resource-limited container |
 
 \* Auth not yet implemented — will require bearer token in a future ticket.
 
@@ -50,6 +51,45 @@ The endpoint:
 6. Deletes the temporary clone regardless of build outcome
 
 The `tmp/` directory is git-ignored and never committed.
+
+## Run service
+
+`POST /container-deployment` accepts a JSON body:
+
+```json
+{ "repo": "owner/repo" }
+```
+
+Both `"owner/repo"` and `"owner-repo"` formats are accepted.
+
+The endpoint:
+1. Normalises the repo identifier and looks for a matching `launchpad/<owner>-<repo>:latest` image
+2. Returns 404 with a list of available built images if no match is found
+3. Starts the container with enforced resource limits (see table below)
+4. Uses `publish_all_ports=True` so Docker auto-assigns an available host port for every `EXPOSE`'d container port
+5. Returns `container_id`, `container_name`, and `ports` on success
+
+### Resource limits
+
+| Resource | Limit |
+|----------|-------|
+| Memory | 512 MB |
+| CPU | 0.5 cores |
+| Privileged mode | Never |
+| Network | Bridge (default) |
+
+### Example response
+
+```json
+{
+  "message": "Container deployed successfully",
+  "container_id": "a3f9c2d1b",
+  "container_name": "romantic_turing",
+  "ports": ["32768:8080/tcp"]
+}
+```
+
+If the image has no `EXPOSE` directives, `ports` will be `"no ports exposed by this image"`.
 
 ## Docker socket access
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -28,6 +28,12 @@ class BuildRequest(BaseModel):
     repo_url: str
 
 
+class DeployRequest(BaseModel):
+    """Payload for the /container-deployment endpoint."""
+
+    repo: str  # Accepts 'owner/repo' or 'owner-repo'
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -181,6 +187,84 @@ async def build_service(request: BuildRequest) -> JSONResponse:
             "message": "Image built successfully",
             "image": image_tag,
             "repo": f"{owner}/{repo_name}",
+        },
+    )
+
+
+@app.post("/container-deployment", tags=["run"])
+async def container_deployment(request: DeployRequest) -> JSONResponse:
+    """Deploy a pre-built image as a container with enforced resource limits.
+
+    Accepts a repo identifier ('owner/repo' or 'owner-repo') and looks for a
+    matching image built by /build-service. If found, starts the container with
+    512 MB memory and 0.5 CPU limits, publishes all exposed ports to random
+    available host ports, and returns the container ID, name, and port mappings.
+    Returns 404 if no matching image exists.
+    """
+    repo_key = request.repo.lower().replace("/", "-").strip()
+    expected_tag = f"launchpad/{repo_key}:latest"
+
+    try:
+        docker_client = docker.from_env()
+        all_images = docker_client.images.list()
+    except docker.errors.DockerException:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Docker daemon is not reachable"},
+        )
+
+    matched = any(expected_tag in (img.tags or []) for img in all_images)
+
+    if not matched:
+        available = [
+            tag
+            for img in all_images
+            for tag in (img.tags or [])
+            if tag.startswith("launchpad/")
+        ]
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": f"No built image found for '{request.repo}'. "
+                         "Build it first using /build-service.",
+                "available_images": available,
+            },
+        )
+
+    try:
+        container = docker_client.containers.run(
+            image=expected_tag,
+            detach=True,
+            publish_all_ports=True,
+            mem_limit="512m",
+            nano_cpus=500_000_000,  # 0.5 CPU cores
+        )
+    except docker.errors.ImageNotFound:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"Image '{expected_tag}' not found"},
+        )
+    except docker.errors.APIError as e:
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Docker failed to start the container", "details": e.explanation},
+        )
+    except docker.errors.DockerException as e:
+        return JSONResponse(
+            status_code=503,
+            content={"error": f"Docker daemon is not reachable: {str(e)}"},
+        )
+
+    container.reload()
+    assigned_ports = _format_ports(container.ports)
+
+    return JSONResponse(
+        status_code=201,
+        content={
+            "message": "Container deployed successfully",
+            "container_id": container.short_id,
+            "container_name": container.name,
+            "ports": assigned_ports if assigned_ports else "no ports exposed by this image",
         },
     )
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -33,25 +33,36 @@ subdomain or path. Also terminates TLS when configured.
 A terminal client for the FastAPI backend. Allows deployments, 
 status checks, and log viewing without the dashboard.
 
-## Request Flow — New Deployment
-```bash
-User/GitHub Webhook
-│
-▼
-Nginx (proxy)
+## Request Flow
+
+Build and run are intentionally separate API calls. A repo must be built before it can be deployed.
+
+### Step 1 — Build (`POST /build-service`)
+```
+User
 │
 ▼
 FastAPI Backend
 │
-├──► PostgreSQL (create deployment record)
+├──► GitHub API (verify repo exists)
 │
-├──► Docker (build image from repo)
+├──► Git (clone repo to tmp/)
 │
-├──► Docker (run container)
+├──► Docker (build image → launchpad/<owner>-<repo>:latest)
 │
-├──► PostgreSQL (update status, store logs)
+└──► tmp/ clone deleted
+```
+
+### Step 2 — Deploy (`POST /container-deployment`)
+```
+User
 │
-└──► Nginx config (register new route)
+▼
+FastAPI Backend
+│
+├──► Docker (find matching launchpad/ image)
+│
+└──► Docker (run container — 512 MB / 0.5 CPU / auto-assigned port)
 ```
 ## Security boundaries
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,78 @@
+# Runbooks
+
+Operational procedures for MyPaaS.
+
+---
+
+## Deploy a repository
+
+### 1. Build the image
+
+```bash
+curl -X POST http://localhost:8000/build-service \
+  -H "Content-Type: application/json" \
+  -d '{"repo_url": "https://github.com/owner/repo"}'
+```
+
+Expected response (`201`):
+```json
+{
+  "message": "Image built successfully",
+  "image": "launchpad/owner-repo:latest",
+  "repo": "owner/repo"
+}
+```
+
+Common errors:
+- `400` — URL is not a valid GitHub URL
+- `404` — Repository not found on GitHub
+- `422` — Repository has no `Dockerfile` at its root
+- `500` — Docker build failed (response includes build log)
+
+### 2. Deploy the container
+
+```bash
+curl -X POST http://localhost:8000/container-deployment \
+  -H "Content-Type: application/json" \
+  -d '{"repo": "owner/repo"}'
+```
+
+Expected response (`201`):
+```json
+{
+  "message": "Container deployed successfully",
+  "container_id": "a3f9c2d1b",
+  "container_name": "romantic_turing",
+  "ports": ["32768:8080/tcp"]
+}
+```
+
+Use the `container_id` or `container_name` to manage the container with `docker` CLI commands.
+
+Common errors:
+- `404` — No built image found. Run step 1 first. The response includes `available_images` listing what is ready.
+- `500` — Docker failed to start the container (response includes details)
+
+### 3. Verify it is running
+
+```bash
+curl http://localhost:8000/docker-status
+```
+
+---
+
+## Stop a running container
+
+```bash
+docker stop <container_name_or_id>
+```
+
+---
+
+## Check container resource usage
+
+```bash
+docker stats <container_name_or_id>
+```
+
+All containers are limited to 512 MB memory and 0.5 CPU cores. If a container is hitting its memory limit it will appear in `docker stats` near 100% of its `MEM LIMIT`.


### PR DESCRIPTION
## What this PR does

adding a new endpoint /container-deployment to deploy the built images from ticket #3
updated root and backend readme
updated the architecture overview

## Related ticket

Closes #4 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

  1. Started the backend — created a venv, installed dependencies, confirmed /health responded before proceeding.         
  2. Built the image first — hit /build-service with the test repo URL since deployment requires a pre-built image. Got
  back launchpad/anyth3ng-test-repo:latest.                                                                               
  3. Tested the failure path — sent a deployment request for a nonexistent repo to confirm the 404 response works and that
   available_images is populated correctly.                                                                               
  4. Tested the happy path — deployed the real repo, got back container_id, container_name, and ports.                    
  5. Verified resource limits independently — ran docker inspect directly against the container to confirm the actual     
  Docker config matched the spec (512 MB / 0.5 CPU), not just trusting the API response.  

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
