### PR TITLE
feat: implement stop and remove service end points

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,8 @@ docker run --env-file .env -p 8000:8000 launchpad-backend
 | GET | /docker-status | None* | List all running containers |
 | POST | /build-service | None* | Clone a GitHub repo and build a Docker image |
 | POST | /container-deployment | None* | Deploy a built image as a resource-limited container |
+| POST | /stop-service | None* | Stop a running container |
+| POST | /remove-service | None* | Remove a stopped container (or force stop + remove) |
 
 \* Auth not yet implemented — will require bearer token in a future ticket.
 
@@ -90,6 +92,48 @@ The endpoint:
 ```
 
 If the image has no `EXPOSE` directives, `ports` will be `"no ports exposed by this image"`.
+
+## Stop service
+
+`POST /stop-service` accepts a JSON body:
+
+```json
+{ "identifier": "owner/repo" }
+```
+
+The `identifier` can be a container ID, container name, or repo name (`owner/repo` or `owner-repo`).
+
+The endpoint:
+1. Tries a direct Docker lookup by ID or name first
+2. Falls back to matching against the `launchpad/<owner>-<repo>:latest` image tag
+3. Returns 409 if the container is already stopped
+4. Returns 404 if no container matches the identifier
+
+## Remove service
+
+`POST /remove-service` accepts a JSON body:
+
+```json
+{ "identifier": "owner/repo", "force": false }
+```
+
+`force` defaults to `false`. The same identifier formats as `/stop-service` are accepted.
+
+| State | `force=false` | `force=true` |
+|---|---|---|
+| Container running | 409 — stop it first | Stops then removes |
+| Container stopped | Removes | Removes |
+| Not found | 404 | 404 |
+
+### Example 409 response (running, no force)
+
+```json
+{
+  "error": "Container 'romantic_turing' is still running. Stop it first using /stop-service, or pass force=true to stop and remove in one step.",
+  "container_id": "a3f9c2d1b",
+  "container_name": "romantic_turing"
+}
+```
 
 ## Docker socket access
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -34,6 +34,19 @@ class DeployRequest(BaseModel):
     repo: str  # Accepts 'owner/repo' or 'owner-repo'
 
 
+class StopRequest(BaseModel):
+    """Payload for the /stop-service endpoint."""
+
+    identifier: str  # Container ID, container name, repo name, or image tag
+
+
+class RemoveRequest(BaseModel):
+    """Payload for the /remove-service endpoint."""
+
+    identifier: str  # Container ID, container name, repo name, or image tag
+    force: bool = False  # Stop the container first if it is still running
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -269,9 +282,151 @@ async def container_deployment(request: DeployRequest) -> JSONResponse:
     )
 
 
+@app.post("/stop-service", tags=["run"])
+async def stop_service(request: StopRequest) -> JSONResponse:
+    """Stop a running container identified by container ID, name, or repo name.
+
+    Looks up the container using the identifier (tried as a direct Docker ID/name
+    first, then as a repo-derived image tag). Returns 409 if the container is
+    already stopped, and 404 if no matching container is found.
+    """
+    try:
+        docker_client = docker.from_env()
+    except docker.errors.DockerException:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Docker daemon is not reachable"},
+        )
+
+    container = _resolve_container(docker_client, request.identifier)
+
+    if container is None:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"No container found for '{request.identifier}'"},
+        )
+
+    if container.status != "running":
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": f"Container '{container.name}' is not running (status: {container.status})",
+                "container_id": container.short_id,
+                "container_name": container.name,
+            },
+        )
+
+    try:
+        container.stop()
+    except docker.errors.APIError as e:
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Failed to stop container", "details": e.explanation},
+        )
+
+    return JSONResponse(
+        content={
+            "message": "Container stopped successfully",
+            "container_id": container.short_id,
+            "container_name": container.name,
+        },
+    )
+
+
+@app.post("/remove-service", tags=["run"])
+async def remove_service(request: RemoveRequest) -> JSONResponse:
+    """Remove a container identified by container ID, name, or repo name.
+
+    If the container is still running and force=false, returns 409 with a prompt
+    to stop it first. If force=true, stops the container before removing it.
+    Returns 404 if no matching container is found.
+    """
+    try:
+        docker_client = docker.from_env()
+    except docker.errors.DockerException:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Docker daemon is not reachable"},
+        )
+
+    container = _resolve_container(docker_client, request.identifier)
+
+    if container is None:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"No container found for '{request.identifier}'"},
+        )
+
+    if container.status == "running":
+        if not request.force:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": (
+                        f"Container '{container.name}' is still running. "
+                        "Stop it first using /stop-service, or pass force=true to stop and remove in one step."
+                    ),
+                    "container_id": container.short_id,
+                    "container_name": container.name,
+                },
+            )
+
+        try:
+            container.stop()
+        except docker.errors.APIError as e:
+            return JSONResponse(
+                status_code=500,
+                content={"error": "Failed to stop container before removal", "details": e.explanation},
+            )
+
+    try:
+        container.remove()
+    except docker.errors.APIError as e:
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Failed to remove container", "details": e.explanation},
+        )
+
+    return JSONResponse(
+        content={
+            "message": "Container removed successfully",
+            "container_id": container.short_id,
+            "container_name": container.name,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _resolve_container(client: docker.DockerClient, identifier: str):
+    """Find a container by ID, name, or repo-derived image tag.
+
+    Tries a direct Docker lookup first (handles full/short IDs and names).
+    Falls back to treating the identifier as a repo name and searching all
+    containers (including stopped ones) for a matching launchpad/ image tag.
+    Returns the Container object, or None if nothing matched.
+    """
+    try:
+        return client.containers.get(identifier)
+    except docker.errors.NotFound:
+        pass
+
+    repo_key = identifier.lower().replace("/", "-").strip()
+    image_tag = f"launchpad/{repo_key}:latest"
+
+    for container in client.containers.list(all=True):
+        try:
+            tags = container.image.tags or []
+        except docker.errors.ImageNotFound:
+            # Image was deleted after the container was created; skip safely
+            continue
+        if image_tag in tags:
+            return container
+
+    return None
+
 
 def _format_ports(ports: dict) -> list[str]:
     """Convert Docker SDK port dict into readable 'host:container/proto' strings."""

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -64,7 +64,31 @@ curl http://localhost:8000/docker-status
 ## Stop a running container
 
 ```bash
-docker stop <container_name_or_id>
+curl -X POST http://localhost:8000/stop-service \
+  -H "Content-Type: application/json" \
+  -d '{"identifier": "owner/repo"}'
+```
+
+The `identifier` can be a container ID, container name, or repo name. Returns 409 if the container is already stopped.
+
+---
+
+## Remove a container
+
+The container must be stopped first:
+
+```bash
+curl -X POST http://localhost:8000/remove-service \
+  -H "Content-Type: application/json" \
+  -d '{"identifier": "owner/repo"}'
+```
+
+To stop and remove in one step, pass `force=true`:
+
+```bash
+curl -X POST http://localhost:8000/remove-service \
+  -H "Content-Type: application/json" \
+  -d '{"identifier": "owner/repo", "force": true}'
 ```
 
 ---


### PR DESCRIPTION
## What this PR does

implements 2 new end points
/stop-service stop a specific running container via name, id, repo
/remove-service removes a stopped container, has a force option that does both

## Related ticket

Closes #5 

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

8 scenarios covering every code path in both endpoints:                                                                 
                                                                                                                          
  1. 404 on both endpoints — identifier that matches nothing                                                              
  2. 409 stop on stopped container — tested twice, once by container name and once by repo name to verify both identifier
  formats resolve correctly                                                                                               
  3. 409 remove running without force — confirms the guard message works before anything is touched
  4. Normal stop → remove flow — the expected happy path in two steps                                                     
  5. force=true remove running container — stops and removes in one shot, then verified with docker ps the container is   
  actually gone                                                                                                           
                                                                                                                          
  Plus one bug surfaced mid-test: the resolver was crashing on containers whose image had since been deleted. Fixed with a
   try/except in _resolve_container before continuing the test run.


## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
