### PR TITLE
feat: implemanted api token bearer authentication + updated project p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ like Railway and Render work under the hood.
 - Deploys built images as containers with enforced CPU and memory resource limits
 - Auto-assigns host ports so deployed services are immediately reachable
 - Monitors running containers and surfaces status via a REST API
+- Secures all API endpoints with bearer token authentication
+- Rate limits requests per IP with separate budgets for general and deployment endpoints
 - Provides a React dashboard for managing deployments and viewing logs
 - Supports GitHub webhook integration for automatic deploys on push
 - Includes a CLI tool for terminal-based deployments
@@ -29,7 +31,11 @@ See [docs/architecture/overview.md](docs/architecture/overview.md)
 
 ## Project status
 
-🚧 In active development — Phase 0 (Foundation)
+**Phase 0 complete.** Project scaffolding, architecture decisions, threat model, FastAPI foundation with `/health` endpoint, and Docker SDK integration with `/docker-status`.
+
+**Phase 1 complete.** Docker image builds from GitHub repos, container deployment with CPU and memory resource limits, stop and remove endpoints, per-IP rate limiting with separate tiers for general and deployment endpoints, and bearer token authentication with auth failure lockout.
+
+🚧 In active development — Phase 2
 
 ## Running locally
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,18 +23,33 @@ docker build -t launchpad-backend .
 docker run --env-file .env -p 8000:8000 launchpad-backend
 ```
 
+## Authentication
+
+All endpoints except `/health` require a bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+The token is set in `backend/.env` as `TOKEN_BEARER`. The server refuses to start if this variable is missing.
+
+| Scenario | Response |
+|---|---|
+| No `Authorization` header | 401 |
+| Malformed header (not `Bearer <token>`) | 401 |
+| Wrong token | 403 |
+| Correct token | Request proceeds |
+
 ## Endpoints
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | /health | None | Service health check |
-| GET | /docker-status | None* | List all running containers |
-| POST | /build-service | None* | Clone a GitHub repo and build a Docker image |
-| POST | /container-deployment | None* | Deploy a built image as a resource-limited container |
-| POST | /stop-service | None* | Stop a running container |
-| POST | /remove-service | None* | Remove a stopped container (or force stop + remove) |
-
-\* Auth not yet implemented — will require bearer token in a future ticket.
+| GET | /docker-status | Bearer | List all running containers |
+| POST | /build-service | Bearer | Clone a GitHub repo and build a Docker image |
+| POST | /container-deployment | Bearer | Deploy a built image as a resource-limited container |
+| POST | /stop-service | Bearer | Stop a running container |
+| POST | /remove-service | Bearer | Remove a stopped container (or force stop + remove) |
 
 ## Build service
 
@@ -161,7 +176,14 @@ A `Retry-After` header is also set on every 429 response.
 
 ### Auth failure lockout
 
-The middleware tracks consecutive `401` responses per IP. After 10 consecutive failures the IP is locked out and receives `429` until a successful request resets the counter. This is a placeholder — it activates automatically once bearer token auth is implemented and the auth layer starts returning `401` responses.
+The middleware tracks consecutive `401` responses per IP. After 10 consecutive failures the IP is locked out for 15 minutes and all requests (including those with a valid token) receive `429`. The lockout expires automatically — there is no manual reset. `/health` remains reachable during a lockout.
+
+```json
+{
+  "error": "Too many authentication failures. IP temporarily locked out.",
+  "retry_after_seconds": 900
+}
+```
 
 ## Docker socket access
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,6 @@
 """Entry point for the Launchpad FastAPI backend."""
 
+import os
 import shutil
 import time
 from collections import defaultdict, deque
@@ -11,10 +12,13 @@ import docker.errors
 import git
 import git.exc
 import httpx
+from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
+
+load_dotenv(Path(__file__).parent.parent / ".env")
 
 app = FastAPI(title="Launchpad", version="0.1.0")
 
@@ -25,9 +29,10 @@ TMP_DIR = Path(__file__).parent.parent / "tmp"
 # ---------------------------------------------------------------------------
 
 _WINDOW_SECONDS = 60
-_GENERAL_LIMIT = 60       # requests per minute for general endpoints
-_DEPLOY_LIMIT = 5         # requests per minute for deployment endpoints
-_AUTH_LOCKOUT_LIMIT = 10  # consecutive auth failures before lockout
+_GENERAL_LIMIT = 60        # requests per minute for general endpoints
+_DEPLOY_LIMIT = 5          # requests per minute for deployment endpoints
+_AUTH_LOCKOUT_LIMIT = 10   # consecutive auth failures before lockout
+_AUTH_LOCKOUT_SECONDS = 900  # lockout duration: 15 minutes
 
 _DEPLOY_ENDPOINTS = {"/build-service", "/container-deployment"}
 _EXEMPT_ENDPOINTS = {"/health"}
@@ -35,7 +40,8 @@ _EXEMPT_ENDPOINTS = {"/health"}
 # In-memory sliding window state (process-local, resets on restart)
 # Keyed by (ip, tier) so deployment and general windows are tracked independently
 _request_log: dict[tuple[str, str], deque] = defaultdict(deque)
-_auth_failures: dict[str, int] = defaultdict(int)  # ip -> consecutive 401 count
+_auth_failures: dict[str, int] = defaultdict(int)   # ip -> consecutive 401 count
+_lockout_start: dict[str, float] = {}                # ip -> timestamp when lockout began
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -43,9 +49,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     General endpoints are limited to 60 requests/minute. Deployment endpoints
     (/build-service, /container-deployment) are limited to 5 requests/minute.
-    /health is exempt. IPs are locked out after 10 consecutive auth failures
-    (placeholder — activates automatically once bearer token auth is in place
-    and the auth layer starts returning 401 responses).
+    /health is exempt. IPs are locked out after 10 consecutive auth failures.
     """
 
     async def dispatch(self, request: Request, call_next) -> JSONResponse:
@@ -56,14 +60,22 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if path in _EXEMPT_ENDPOINTS:
             return await call_next(request)
 
-        # Auth failure lockout (placeholder until bearer token auth is implemented)
+        # Auth failure lockout — expires after 15 minutes automatically
         if _auth_failures[ip] >= _AUTH_LOCKOUT_LIMIT:
-            return JSONResponse(
-                status_code=429,
-                content={
-                    "error": "Too many authentication failures. IP temporarily locked out.",
-                },
-            )
+            lockout_age = time.time() - _lockout_start.get(ip, 0)
+            if lockout_age < _AUTH_LOCKOUT_SECONDS:
+                retry_after = int(_AUTH_LOCKOUT_SECONDS - lockout_age) + 1
+                return JSONResponse(
+                    status_code=429,
+                    content={
+                        "error": "Too many authentication failures. IP temporarily locked out.",
+                        "retry_after_seconds": retry_after,
+                    },
+                    headers={"Retry-After": str(retry_after)},
+                )
+            # Lockout expired — reset and allow the request through
+            _auth_failures[ip] = 0
+            _lockout_start.pop(ip, None)
 
         # Sliding window rate limit — keyed by (ip, tier) to keep windows independent
         tier = "deploy" if path in _DEPLOY_ENDPOINTS else "general"
@@ -91,15 +103,68 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         timestamps.append(now)
         response = await call_next(request)
 
-        # Track consecutive auth failures; reset on any success
+        # Track consecutive auth failures; record lockout start when threshold is first hit
         if response.status_code == 401:
             _auth_failures[ip] += 1
+            if _auth_failures[ip] >= _AUTH_LOCKOUT_LIMIT and ip not in _lockout_start:
+                _lockout_start[ip] = time.time()
         elif response.status_code < 400:
             _auth_failures[ip] = 0
+            _lockout_start.pop(ip, None)
 
         return response
 
 
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Validate the Bearer token on every request except /health.
+
+    Reads TOKEN_BEARER from the environment at startup. Requests without an
+    Authorization header return 401. Requests with a token that does not match
+    return 403. /health is exempt and requires no token.
+    """
+
+    def __init__(self, app):
+        """Load the expected bearer token from the environment."""
+        super().__init__(app)
+        self._token = os.environ.get("TOKEN_BEARER", "")
+        if not self._token:
+            raise RuntimeError("TOKEN_BEARER is not set in the environment")
+
+    async def dispatch(self, request: Request, call_next) -> JSONResponse:
+        """Check the Authorization header before passing the request."""
+        if request.url.path in _EXEMPT_ENDPOINTS:
+            return await call_next(request)
+
+        auth_header = request.headers.get("Authorization", "")
+
+        if not auth_header:
+            return JSONResponse(
+                status_code=401,
+                content={"error": "Missing Authorization header. Expected: Bearer <token>"},
+            )
+
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            return JSONResponse(
+                status_code=401,
+                content={"error": "Malformed Authorization header. Expected: Bearer <token>"},
+            )
+
+        if parts[1] != self._token:
+            return JSONResponse(
+                status_code=403,
+                content={"error": "Invalid token"},
+            )
+
+        return await call_next(request)
+
+
+# Middleware is executed in reverse registration order.
+# AuthMiddleware is added first (inner), RateLimitMiddleware second (outer).
+# Execution order: RateLimit → Auth → endpoint.
+# This means RateLimitMiddleware sees the 401/403 responses from AuthMiddleware
+# and can correctly count them toward the auth failure lockout.
+app.add_middleware(AuthMiddleware)
 app.add_middleware(RateLimitMiddleware)
 
 


### PR DESCRIPTION
## What this PR does

Implemented API token bearer authentication

## Related ticket

Closes #7 

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

ran 8 scenarios against the auth middleware:                                                                         
                                                                                                                          
  1. /health with no token — confirmed it's exempt and returns 200                                                        
  2. No Authorization header — confirmed 401 with a descriptive message                                                   
  3. Malformed header (token sent without Bearer prefix) — confirmed 401                                                  
  4. Wrong token — confirmed 403                                                                                          
  5. Correct token — confirmed 200, request goes through                                                                  
  6. Auth failure lockout — sent 10 unauthenticated requests, confirmed the 11th returns 429 with retry_after_seconds: 900
  7. Correct token while locked out — confirmed 429, lockout blocks everything including valid tokens                     
  8. /health while IP is locked out — confirmed still returns 200, exempt from lockout                                    
                                                                                                                          
  Two bugs were caught during the run:                                                                                    
                                                                                                                          
  - Middleware order — 401s weren't being counted because AuthMiddleware was outermost and short-circuited before         
  RateLimitMiddleware could see the response. Fixed by swapping registration order.                                       
  - Lockout reset — "reset on successful auth" is impossible once locked out since the lockout blocks before auth runs.   
  Changed to a 15-minute time-based expiry instead. 

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
