### PR TITLE
feat: setup postgresql for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ like Railway and Render work under the hood.
 - Deploys built images as containers with enforced CPU and memory resource limits
 - Auto-assigns host ports so deployed services are immediately reachable
 - Monitors running containers and surfaces status via a REST API
+- Persists deployment state in PostgreSQL via SQLAlchemy
 - Secures all API endpoints with bearer token authentication
 - Rate limits requests per IP with separate budgets for general and deployment endpoints
 - Provides a React dashboard for managing deployments and viewing logs

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,15 @@ docker build -t launchpad-backend .
 docker run --env-file .env -p 8000:8000 launchpad-backend
 ```
 
+## Environment variables
+
+All secrets and config live in the root `.env` (git-ignored). The server refuses to start if required variables are missing.
+
+| Variable | Required | Description |
+|---|---|---|
+| `TOKEN_BEARER` | Yes | Bearer token for API authentication |
+| `DATABASE_URL` | Yes | PostgreSQL connection string (`postgresql://user:pass@host:5432/db`) |
+
 ## Authentication
 
 All endpoints except `/health` require a bearer token:
@@ -31,7 +40,7 @@ All endpoints except `/health` require a bearer token:
 Authorization: Bearer <token>
 ```
 
-The token is set in `backend/.env` as `TOKEN_BEARER`. The server refuses to start if this variable is missing.
+The token is set in the root `.env` as `TOKEN_BEARER`. The server refuses to start if this variable is missing.
 
 | Scenario | Response |
 |---|---|
@@ -183,6 +192,32 @@ The middleware tracks consecutive `401` responses per IP. After 10 consecutive f
   "error": "Too many authentication failures. IP temporarily locked out.",
   "retry_after_seconds": 900
 }
+```
+
+## Database
+
+Launchpad uses PostgreSQL via SQLAlchemy. The connection is configured through `DATABASE_URL` in the root `.env`.
+
+### Deployment model
+
+The `deployments` table tracks every container deployment:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Integer | Auto-increment primary key |
+| `image_name` | String | e.g. `launchpad/owner-repo:latest` |
+| `container_id` | String (unique) | Docker container ID |
+| `status` | String | `running` or `down` |
+| `repo_name` | String | e.g. `Anyth3nG/test-repo` |
+| `port` | String (nullable) | Host port mapping, e.g. `32768:8080/tcp`; null if no ports exposed |
+| `created_at` | DateTime (tz-aware) | Set automatically at insertion |
+
+### Setup
+
+Tables are created automatically on startup via `init_db()`. The database user needs `CREATE` privilege on the public schema:
+
+```sql
+GRANT CREATE ON SCHEMA public TO <your_db_user>;
 ```
 
 ## Docker socket access

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv==1.1.0
 docker==7.1.0
 gitpython==3.1.44
 httpx==0.28.1
+sqlalchemy==2.0.41
+psycopg2-binary==2.9.10

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -1,0 +1,55 @@
+"""Database connection and ORM models for Launchpad."""
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import Column, DateTime, Integer, String, create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+load_dotenv(Path(__file__).parent.parent.parent / ".env")
+
+_DATABASE_URL = os.environ.get("DATABASE_URL")
+if not _DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not set in the environment")
+
+engine = create_engine(_DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+class Base(DeclarativeBase):
+    """Shared declarative base for all ORM models."""
+
+
+class Deployment(Base):
+    """Represents a container deployment managed by Launchpad.
+
+    Tracks the lifecycle of a deployed container from creation through
+    shutdown, including which image and repo it originated from and
+    the host port it was assigned.
+    """
+
+    __tablename__ = "deployments"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    image_name = Column(String, nullable=False)
+    container_id = Column(String, nullable=False, unique=True)
+    status = Column(String, nullable=False, default="running")  # 'running' | 'down'
+    repo_name = Column(String, nullable=False)
+    port = Column(String, nullable=True)  # host:container/proto format; null if no ports exposed
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+
+def init_db() -> None:
+    """Create all tables if they do not already exist."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """Yield a database session and ensure it is closed after use."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).parent.parent.parent / ".env")
 
 app = FastAPI(title="Launchpad", version="0.1.0")
 


### PR DESCRIPTION
## What this PR does

Set up PostgreSQL integration using SQLAlchemy. Created the database 
connection module and Deployment model with fields for image name, 
container ID, status, repo name, uptime, and port.

## Related ticket

Closes #8 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Infrastructure

## Testing done

7 tests against the database module directly (no HTTP, no running server):                                              
                                                                                                                          
  1. Connection — confirmed SQLAlchemy could connect to PostgreSQL and returned the server version                        
  2. init_db() — called it and verified the deployments table was created in the database
  3. Insert — created a full Deployment record and confirmed it got an auto-assigned id and a timezone-aware created_at   
  4. Query — fetched the same record back and verified every field matched what was inserted                              
  5. Update — changed status from running to down, committed, and confirmed the change persisted                          
  6. Unique constraint — tried inserting a second record with the same container_id, confirmed it raised IntegrityError   
  and was correctly rejected                                                                                              
  7. Null port — inserted a record with port=None (for images with no EXPOSE) and confirmed it stored and returned None   
  cleanly                                                                                                                 
                  
  All test records were deleted from the database at the end. 

## Screenshots (if UI change)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
